### PR TITLE
fix: update correct gateway endpoint for delete and update API

### DIFF
--- a/internal/bucketeer/bucketeer.go
+++ b/internal/bucketeer/bucketeer.go
@@ -222,7 +222,8 @@ func (c *apiClient) CreateCodeReference(ctx context.Context, opts options.Option
 }
 
 func (c *apiClient) UpdateCodeReference(ctx context.Context, opts options.Options, id string, ref CodeReference) error {
-	url := c.apiEndpoint + "/v1/code_reference/" + id
+	ref.ID = id
+	url := c.apiEndpoint + "/v1/code_reference"
 	body, err := json.Marshal(ref)
 	if err != nil {
 		return err
@@ -250,7 +251,7 @@ func (c *apiClient) UpdateCodeReference(ctx context.Context, opts options.Option
 }
 
 func (c *apiClient) DeleteCodeReference(ctx context.Context, opts options.Options, id string) error {
-	url := c.apiEndpoint + "/v1/code_reference/" + id
+	url := c.apiEndpoint + "/v1/code_reference?id=" + id
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
The correct endpoint can be seen here: https://docs.bucketeer.io/api#tag/code-references