### PR TITLE
ci: use app token for goreleaser homebrew formula push

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -10,7 +10,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # goreleaser uploads release assets
+      contents: read
       packages: write # push images to ghcr.io
 
     steps:
@@ -28,6 +28,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # goreleaser uploads release assets and commits the updated Homebrew
+      # formula directly to the protected main branch, so it needs an app
+      # token (the app is in the branch protection bypass list).
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
@@ -35,4 +45,4 @@ jobs:
           version: '~> v2'
           args: release --clean --skip=validate
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The goreleaser commits the updated Homebrew formula directly to the protected main branch, which GITHUB_TOKEN cannot do. Use a GitHub App token instead; the app must be in the branch protection bypass list.