### PR TITLE
ci: fetch full history and tags for goreleaser

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # goreleaser derives the version from git tags; a shallow checkout
+          # has none (breaks workflow_dispatch re-runs of a release).
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
The goreleaser needs the git tags to determine the release version; the default shallow checkout has none, which breaks workflow_dispatch runs.